### PR TITLE
Use config to include packages

### DIFF
--- a/Pulumi.pulumi-import-repro-ts-dev.yaml
+++ b/Pulumi.pulumi-import-repro-ts-dev.yaml
@@ -1,2 +1,3 @@
 config:
   aws:region: us-west-2
+  cloud-aws:functionIncludePackages: qs,uuid


### PR DESCRIPTION
Pulumi did not correctly identify `qs` and `uuid` as being module import
captures in the function.  This led to runtime failures due to the
packages being missing from the lambda code upload.  This is being
tracked by https://github.com/pulumi/pulumi/issues/1588.  In the
meantime, we can use manual configuration to include the packages in
the uploaded functions.